### PR TITLE
0.9.1 - Update for paperclipped Asset model method call for thumbnails

### DIFF
--- a/app/controllers/admin/tiny_paper_controller.rb
+++ b/app/controllers/admin/tiny_paper_controller.rb
@@ -8,7 +8,7 @@ class Admin::TinyPaperController < ApplicationController
     filter_by_params([:view, :size])
     list_params[:images] = 'images'
     @assets = Asset.assets_paginate(list_params)
-    @thumbnails = Asset.attachment_definitions[:asset][:styles]
+    @thumbnails = Asset.thumbnail_definitions
 
     respond_to do |f|
       f.html { render }


### PR DESCRIPTION
# User description
I've updated the method call on the paperclipped extension used by the controller

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>TinyPaperController</code> to retrieve thumbnail definitions for assets using the <code>Asset.thumbnail_definitions</code> method, replacing the direct access to <code>attachment_definitions</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>cristi.duma@gmail.com</td><td>FIX-fixed-to-work-with...</td><td>January 17, 2011</td></tr>
<tr><td>cristi.duma@aissac.ro</td><td>updated-for-0.9</td><td>October 14, 2009</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/ihoka-me/radiant-tiny-paper-extension/8?tool=ast>(Baz)</a>.